### PR TITLE
fix humidity H5 compensation parameter

### DIFF
--- a/bme280.go
+++ b/bme280.go
@@ -334,7 +334,7 @@ func (b *BME280) loadCompensation() error {
 	b.compensation.hum.H2 = int16(h2Data[1])<<8 | int16(h2Data[0])
 	b.compensation.hum.H3 = uint8(h2Data[2])
 	b.compensation.hum.H4 = int16(h2Data[3])<<4 | int16(h2Data[4]&0x0F)
-	b.compensation.hum.H5 = int16(h2Data[4]&0xF0)<<4 | int16(h2Data[5])
+	b.compensation.hum.H5 = int16(h2Data[5])<<4 | int16(h2Data[4]>>4&0x0F)
 	return nil
 }
 


### PR DESCRIPTION
Hi,

humidity value is wrong (at least in my environment) due to wrong construction of H5 compensation parameter.
by analyzing the Bosch driver I realized that the byte and halfbyte are appended the other way round.

[BoschSensortec BME280](https://github.com/BoschSensortec/BME280_driver/blob/master/bme280.c) in parse_humidity_calib_data:
			dig_h5_msb = (int16_t)(int8_t)reg_data[5] * 16;
			dig_h5_lsb = (int16_t)(reg_data[4] >> 4);
			calib_data->dig_h5 = dig_h5_msb | dig_h5_lsb;

best regards,
walter